### PR TITLE
Stencils and DCCRG default neighborhood of width 3.

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -122,7 +122,7 @@ void initializeGrids(
    
    mpiGrid.set_initial_length(grid_length)
       .set_load_balancing_method(&P::loadBalanceAlgorithm[0])
-      .set_neighborhood_length(neighborhood_size)
+      .set_neighborhood_length(3)
       .set_maximum_refinement_level(P::amrMaxSpatialRefLevel)
       .set_periodic(sysBoundaries.isBoundaryPeriodic(0),
                     sysBoundaries.isBoundaryPeriodic(1),
@@ -910,7 +910,7 @@ void initializeStencils(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    mpiGrid.add_neighborhood(SYSBOUNDARIES_EXTENDED_NEIGHBORHOOD_ID, neighborhood);
 
    /*add face neighbors if stencil width larger than 2*/
-   for (int d = 3; d <= VLASOV_STENCIL_WIDTH; d++) {
+   for (int d = 3; d <= VLASOV_STENCIL_WIDTH+1; d++) {
       neighborhood.push_back({{ d, 0, 0}});
       neighborhood.push_back({{-d, 0, 0}});
       neighborhood.push_back({{0, d, 0}});
@@ -925,7 +925,7 @@ void initializeStencils(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    
    /*stencils for semilagrangian propagators*/ 
    neighborhood.clear();
-   for (int d = -VLASOV_STENCIL_WIDTH; d <= VLASOV_STENCIL_WIDTH; d++) {
+   for (int d = -VLASOV_STENCIL_WIDTH-1; d <= VLASOV_STENCIL_WIDTH+1; d++) {
      if (d != 0) {
         neighborhood.push_back({{d, 0, 0}});
         neighborhood.push_back({{0, d, 0}});
@@ -951,7 +951,7 @@ void initializeStencils(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
    mpiGrid.add_neighborhood(DIST_FUNC_NEIGHBORHOOD_ID, neighborhood);
    
    neighborhood.clear();
-   for (int d = -VLASOV_STENCIL_WIDTH; d <= VLASOV_STENCIL_WIDTH; d++) {
+   for (int d = -VLASOV_STENCIL_WIDTH-1; d <= VLASOV_STENCIL_WIDTH+1; d++) {
      if (d != 0) {
         neighborhood.push_back({{d, 0, 0}});
      }
@@ -960,7 +960,7 @@ void initializeStencils(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 
    
    neighborhood.clear();
-   for (int d = -VLASOV_STENCIL_WIDTH; d <= VLASOV_STENCIL_WIDTH; d++) {
+   for (int d = -VLASOV_STENCIL_WIDTH-1; d <= VLASOV_STENCIL_WIDTH+1; d++) {
      if (d != 0) {
         neighborhood.push_back({{0, d, 0}});
      }
@@ -969,7 +969,7 @@ void initializeStencils(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpi
 
    
    neighborhood.clear();
-   for (int d = -VLASOV_STENCIL_WIDTH; d <= VLASOV_STENCIL_WIDTH; d++) {
+   for (int d = -VLASOV_STENCIL_WIDTH-1; d <= VLASOV_STENCIL_WIDTH+1; d++) {
      if (d != 0) {
         neighborhood.push_back({{0, 0, d}});
      }

--- a/projects/Magnetosphere/Magnetosphere.cpp
+++ b/projects/Magnetosphere/Magnetosphere.cpp
@@ -631,10 +631,10 @@ namespace projects {
      if(myRank == MASTER_RANK) std::cout << "Maximum refinement level is " << mpiGrid.mapping.get_maximum_refinement_level() << std::endl;
       
      // Leave boundary cells and a bit of safety margin
-     const int bw = 2* VLASOV_STENCIL_WIDTH;
-     const int bw2 = 2*(bw + VLASOV_STENCIL_WIDTH);
-     const int bw3 = 2*(bw2 + VLASOV_STENCIL_WIDTH);
-     const int bw4 = 2*(bw3 + VLASOV_STENCIL_WIDTH);
+     const int bw = 2* (VLASOV_STENCIL_WIDTH+1);
+     const int bw2 = 2*(bw + VLASOV_STENCIL_WIDTH+1);
+     const int bw3 = 2*(bw2 + VLASOV_STENCIL_WIDTH+1);
+     const int bw4 = 2*(bw3 + VLASOV_STENCIL_WIDTH+1);
 
      // Calculate regions for refinement
      if (P::amrMaxSpatialRefLevel > 0) {


### PR DESCRIPTION
This is an uncontroversial bugfix. #teamshelob

The default stencil for DCCRG as well as the translation stencils need to be wider than 2 because of the way DCCRG handles neighbours at AMR interfaces, namely in terms of the local cell width, where Vlasiator needs 2 neighbours, i.e. 2 coarse ones even if the calling cell is refined.

Tests with a width of 4 didn't have significant differences.