### PR TITLE
Allow restarting from 32bit fsgrid fields.

### DIFF
--- a/ioread.cpp
+++ b/ioread.cpp
@@ -785,6 +785,7 @@ template<unsigned long int N> bool readFsGridVariable(
    vlsv::datatype::type dataType;
    uint64_t byteSize;
    list<pair<string,string> > attribs;
+   bool convertFloatType = false;
    
    attribs.push_back(make_pair("name",variableName));
    attribs.push_back(make_pair("mesh","fsgrid"));
@@ -794,8 +795,7 @@ template<unsigned long int N> bool readFsGridVariable(
       return false;
    }
    if(! (dataType == vlsv::datatype::type::FLOAT && byteSize == sizeof(Real))) {
-      logFile << "(RESTART)  ERROR: Attempting to read fsgrid variable " << variableName << ", but it is not in the same floating point format as the simulation expects (" << byteSize*8 << " bits instead of " << sizeof(Real)*8 << ")." << endl << write;
-      return false;
+      convertFloatType = true;
    }
 
    // Are we restarting from the same number of tasks, or a different number?
@@ -829,9 +829,24 @@ template<unsigned long int N> bool readFsGridVariable(
       // Read into buffer
       std::vector<Real> buffer(storageSize*N);
 
-      if(file.readArray("VARIABLE",attribs, localStartOffset, storageSize, (char*)buffer.data()) == false) {
-         logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
-         return false;
+      if(!convertFloatType) {
+         if(file.readArray("VARIABLE",attribs, localStartOffset, storageSize, (char*)buffer.data()) == false) {
+            logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
+            return false;
+         }
+      } else {
+
+         // Read to temporary float buffer
+         std::vector<float> readBuffer(storageSize*N);
+
+         if(file.readArray("VARIABLE",attribs, localStartOffset, storageSize, (char*)readBuffer.data()) == false) {
+            logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
+            return false;
+         }
+
+         for(int i=0; i<storageSize*N; i++) {
+            buffer[i] = readBuffer[i];
+         }
       }
       
       // Assign buffer into fsgrid
@@ -900,10 +915,22 @@ template<unsigned long int N> bool readFsGridVariable(
          // Read into buffer
          std::vector<Real> buffer(thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2]*N);
 
-         // TODO: Should these be multireads instead? And/or can this be parallelized?
-         if(file.readArray("VARIABLE",attribs, fileOffset, thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2], (char*)buffer.data()) == false) {
-            logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
-            return false;
+         if(!convertFloatType) {
+            // TODO: Should these be multireads instead? And/or can this be parallelized?
+            if(file.readArray("VARIABLE",attribs, fileOffset, thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2], (char*)buffer.data()) == false) {
+               logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
+               return false;
+            }
+         } else {
+            std::vector<float> readBuffer(thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2]*N);
+            if(file.readArray("VARIABLE",attribs, fileOffset, thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2], (char*)readBuffer.data()) == false) {
+               logFile << "(RESTART)  ERROR: Failed to read fsgrid variable " << variableName << endl << write;
+               return false;
+            }
+
+            for(int i=0; i< thatTasksSize[0]*thatTasksSize[1]*thatTasksSize[2]*N; i++) {
+               buffer[i]=readBuffer[i];
+            }
          }
 
          // Read every source rank that we have an overlap with.

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -795,6 +795,7 @@ template<unsigned long int N> bool readFsGridVariable(
       return false;
    }
    if(! (dataType == vlsv::datatype::type::FLOAT && byteSize == sizeof(Real))) {
+      logFile << "(RESTART) Converting floating point format of fsgrid variable " << variableName << " from " << byteSize * 8 << " bits to " << sizeof(Real) * 8 << " bits." << endl << write;
       convertFloatType = true;
    }
 

--- a/iowrite.cpp
+++ b/iowrite.cpp
@@ -1413,7 +1413,7 @@ bool writeRestart(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
    ));
    
    //Write necessary variables:
-   const bool writeAsFloat = false;
+   const bool writeAsFloat = P::writeRestartAsFloat;
    for (uint i=0; i<restartReducer.size(); ++i) {
       writeDataReducer(mpiGrid, local_cells,
             perBGrid, EGrid, EHallGrid, EGradPeGrid, momentsGrid, dPerBGrid, dMomentsGrid,

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -118,6 +118,7 @@ Real P::electronTemperature = 0.0;
 string P::restartFileName = string("");
 bool P::isRestart=false;
 int P::writeAsFloat = false;
+int P::writeRestartAsFloat = false;
 string P::loadBalanceAlgorithm = string("");
 string P::loadBalanceTolerance = string("");
 uint P::rebalanceInterval = numeric_limits<uint>::max();
@@ -182,6 +183,7 @@ bool Parameters::addParameters(){
    Readparameters::add("hallMinimumRho", "Minimum rho value used for the Hall and electron pressure gradient terms in the Lorentz force and in the field solver. Default is very low and has no effect in practice.", 1.0);
    Readparameters::add("project", "Specify the name of the project to use. Supported to date (20150610): Alfven Diffusion Dispersion Distributions Firehose Flowthrough Fluctuations Harris KHB Larmor Magnetosphere Multipeak Riemann1 Shock Shocktest Template test_fp testHall test_trans VelocityBox verificationLarmor", string(""));
 
+   Readparameters::add("restart.write_as_float","If true, write restart fields in floats instead of doubles", false);
    Readparameters::add("restart.filename","Restart from this vlsv file. No restart if empty file.",string(""));
    
    Readparameters::add("gridbuilder.geometry","Simulation geometry XY4D,XZ4D,XY5D,XZ5D,XYZ6D",string("XYZ6D"));
@@ -430,6 +432,7 @@ bool Parameters::getParameters(){
    Readparameters::get("hallMinimumRho",hallRho);
    P::hallMinimumRhom = hallRho*physicalconstants::MASS_PROTON;
    P::hallMinimumRhoq = hallRho*physicalconstants::CHARGE;
+   Readparameters::get("restart.write_as_float", P::writeRestartAsFloat);
    Readparameters::get("restart.filename",P::restartFileName);
    P::isRestart=(P::restartFileName!=string(""));
 

--- a/parameters.h
+++ b/parameters.h
@@ -124,6 +124,7 @@ struct Parameters {
    static std::string restartFileName; /*!< If defined, restart from this file*/
    static bool isRestart; /*!< true if this is a restart, false otherwise */
    static int writeAsFloat; /*!< true if writing into VLSV in floats instead of doubles, false otherwise */
+   static int writeRestartAsFloat; /*!< true if writing into restart files in floats instead of doubles, false otherwise */
    static bool dynamicTimestep; /*!< If true, timestep is set based on  CFL limit */
    
    static std::string projectName; /*!< Project to be used in this run. */

--- a/testpackage/tests/restart_write/restart_write.cfg
+++ b/testpackage/tests/restart_write/restart_write.cfg
@@ -18,6 +18,10 @@ system_write_distribution_xline_stride = 0
 system_write_distribution_yline_stride = 0
 system_write_distribution_zline_stride = 0
 
+[restart]
+#write_as_float = 1
+
+
 [variables]
 output = vg_rhom
 output = fg_e

--- a/testpackage/tests/restart_write/restart_write.cfg
+++ b/testpackage/tests/restart_write/restart_write.cfg
@@ -7,6 +7,7 @@ dynamic_timestep = 1
 ParticlePopulations = proton
 
 [io]
+#write_as_float = 1
 write_initial_state = 0
 restart_walltime_interval = 1000
 


### PR DESCRIPTION
As opposed to what https://github.com/fmihpc/vlasiator/pull/482 said, this appears to work well (tested both with the testpackage restart_write/restart_read test and with a small Magnetosphere).

Note that to enable writing restart as float, that setting needs to still be enabled in iowrite.cpp:1416.