### PR TITLE
Clean workspace as part of the build tasks, not as a separate CI task.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,16 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  clean_workspace:
-    # Cleans up Carrington workspace, deleting any old lingering directories and files
-    runs-on: carrington
-    steps:
-      - name: Delete files and directories
-        run: |
-          rm -rf libraries library-build testpackage
-          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
-          rm -f *.xml
-
   build_libraries:
     # Build libraries for the current version of the docker image
     # (to be used in any subsequent compilation and run jobs on said image)
@@ -135,9 +125,13 @@ jobs:
     # Build Vlasiator with testpackage flags, on the carrington cluster
     # (for subsequent running of the integration test package)
     runs-on: carrington
-    needs: clean_workspace
 
     steps:
+    - name: Clean workspace
+        run: |
+          rm -rf libraries library-build testpackage
+          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm -f *.xml
     - name: Checkout source
       uses: actions/checkout@v3
       with: 
@@ -196,9 +190,13 @@ jobs:
   build_tools:
     # Build vlsvdiff and vlsvextract for testpackage use
     runs-on: carrington
-    needs: clean_workspace
       
     steps:
+    - name: Clean workspace
+        run: |
+          rm -rf libraries library-build testpackage
+          rm -f libraries.tar.zst dtestpackage_check_description.txt testpackage-output.tar.gz metrics.txt stdout.txt stderr.txt testpackage_output_variables.txt
+          rm -f *.xml
     - name: Checkout source
       uses: actions/checkout@v3 
       with: 
@@ -222,7 +220,7 @@ jobs:
   run_testpackage:
     # Run the testpackage on the carrington cluster
     runs-on: carrington
-    needs: [clean_workspace, build_testpackage, build_tools]
+    needs: [build_testpackage, build_tools]
     continue-on-error: true
 
     steps:
@@ -268,7 +266,7 @@ jobs:
     # Build IonosphereSolverTests miniApp (currently broken)
     runs-on: carrington
       #container: ursg/vlasiator_ci:20230220_1
-    needs: [clean_workspace, build_libraries]
+    needs: [build_libraries]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3 


### PR DESCRIPTION
(As the individual tasks might otherwise have been picked up by
 different runners, and thus been pointless)